### PR TITLE
Add support for subdirectory dewfile inclusion

### DIFF
--- a/dew/dependencyprocessor.py
+++ b/dew/dependencyprocessor.py
@@ -100,7 +100,7 @@ class DependencyProcessor(object):
         dewfile_path = os.path.join(self.get_remote().get_source_dir(), 'dewfile.json')
         return os.path.isfile(dewfile_path)
 
-    def get_dewfile(self) -> DewFile or None:
+    def get_dewfile(self) -> Optional[DewFile]:
         dewfile_path = os.path.join(self.get_remote().get_source_dir(), 'dewfile.json')
         if os.path.isfile(dewfile_path):
             parser = ProjectFilesParser(dewfile_path)

--- a/dew/lockfile.py
+++ b/dew/lockfile.py
@@ -1,0 +1,24 @@
+import fasteners, threading
+from dew.impl import CommandData
+
+class LockFile(fasteners.InterProcessLock):
+    def __init__(self, path: str, data: CommandData):
+        self.data = data
+        super().__init__(path)
+
+    def __enter__(self):
+        gotten = super().acquire(blocking=False)
+        if not gotten:
+            self.data.view.info("Waiting for another dew to complete."
+                                " Press Ctrl-C to abort.")
+            gotten = super().acquire()
+            if not gotten:
+                # This shouldn't happen, but just incase...
+                raise threading.ThreadError("Unable to acquire a file lock"
+                                            " on `%s` (when used as a"
+                                            " context manager)" % self.path)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        super().release()

--- a/dew/projectprocessor.py
+++ b/dew/projectprocessor.py
@@ -7,7 +7,7 @@ from dew.projectproperties import ProjectProperties
 from dew.dependencygraph import DependencyGraph
 from dew.dependencyprocessor import DependencyProcessor
 from dew.depstate import DependencyStateController
-from dew.dewfile import DewFile, Dependency
+from dew.dewfile import DewFile, Dependency, ProjectFilesParser
 from dew.exceptions import BuildError, DewfileError
 from dew.storage import StorageController, BuildType, BUILD_TYPE_NAMES
 from dew.view import View
@@ -37,6 +37,14 @@ class ProjectProcessor(object):
 
         while len(dewfile_stack) > 0:
             dewfile, parent_name = dewfile_stack.pop()
+
+            for subdir in dewfile.subdirectories:
+                dewfile_path = os.path.join(os.path.dirname(dewfile.path), subdir, 'dewfile.json')
+                if os.path.isfile(dewfile_path):
+                    parser = ProjectFilesParser(dewfile_path)
+                    child_dewfile = parser.parse()
+                    dewfile_stack.append((child_dewfile, None))
+
             for dep in dewfile.dependencies:
                 dep_processor = self.make_processor(dep, dewfile)
                 label = dep_processor.get_label()


### PR DESCRIPTION
dewfile.json now has an optional 'subdirectories' array which
is used to relatively reference subdirectories containing
additional dewfiles to extend the dependency graph.

Also some codebase cleanups and a nicer LockFile class.