### PR TITLE
Pass host project's build type and compiler to dew

### DIFF
--- a/dew/data/cmake/dew.cmake
+++ b/dew/data/cmake/dew.cmake
@@ -18,6 +18,22 @@ function(integrate_dew)
     endif()
 
     #
+    # Advise the user that setting the build type is necessary for debug dependencies.
+    #
+    if (NOT CMAKE_BUILD_TYPE)
+        message(WARNING "CMAKE_BUILD_TYPE is not set. Dew will build release dependencies by default.")
+    endif()
+
+    #
+    # Acquaint CMake with dew prefix
+    #
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL Debug)
+        set(dew_cmake_prefix_suffix debug)
+    else()
+        set(dew_cmake_prefix_suffix release)
+    endif()
+
+    #
     # Run dew update
     #
     option(DEW_AUTOUPDATE "Automatically update dew prefixes as part of cmake generation." ON)
@@ -32,20 +48,13 @@ function(integrate_dew)
             message(FATAL_ERROR "Failed to install dew with pip: result: ${install_dew_result}.")
         endif()
         message(STATUS "Building dew dependencies")
-        execute_process(COMMAND "${Python3_EXECUTABLE}" -m dew update WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        execute_process(COMMAND "${Python3_EXECUTABLE}" -m dew update --CC "${CMAKE_C_COMPILER}"
+                        --CXX "${CMAKE_CXX_COMPILER}" --build-type ${dew_cmake_prefix_suffix}
+                        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
                         RESULT_VARIABLE dew_res)
         if(NOT dew_res EQUAL 0)
             message(FATAL_ERROR "Unable to run dew: ${dew_res}")
         endif()
-    endif()
-
-    #
-    # Acquaint CMake with dew prefix
-    #
-    if ("${CMAKE_BUILD_TYPE}" STREQUAL Debug)
-        set(dew_cmake_prefix_suffix debug)
-    else()
-        set(dew_cmake_prefix_suffix release)
     endif()
 
     set(dew_output_path "${CMAKE_CURRENT_SOURCE_DIR}/.dew")

--- a/dew/data/cmake/dew.cmake
+++ b/dew/data/cmake/dew.cmake
@@ -7,7 +7,8 @@
 # It is encouraged to check this file into your project's VCS. Doing so will allow your cmake project to easily
 # integrate with Dew.
 #
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
+cmake_policy(SET CMP0057 NEW) # IN_LIST operator
 
 function(integrate_dew)
     #
@@ -73,33 +74,27 @@ function(integrate_dew)
     # Check if we have already added the dew directory to CMAKE_PREFIX_PATH
     #
     set(needs_new_prefix TRUE)
-    foreach (path ${CMAKE_PREFIX_PATH})
-        if (path STREQUAL "${dew_cmake_prefix_path}")
-            set(needs_new_prefix FALSE)
-            break()
-        endif()
-    endforeach()
+    if ("${dew_cmake_prefix_path}" IN_LIST CMAKE_PREFIX_PATH)
+        set(needs_new_prefix FALSE)
+    endif()
 
     #
     # Check if we have already added the dew cmake module directory to CMAKE_MODULE_PATH
     #
     set(needs_new_module_path TRUE)
-    foreach (path ${CMAKE_MODULE_PATH})
-        if (path STREQUAL "${dew_cmake_module_path}")
-            set(needs_new_module_path FALSE)
-            break()
-        endif()
-    endforeach()
+    if ("${dew_cmake_module_path}" IN_LIST CMAKE_MODULE_PATH)
+        set(needs_new_module_path FALSE)
+    endif()
 
     #
-    # Add dew directory to CMAKE_PREFIX_PATH if necesary
+    # Add dew directory to CMAKE_PREFIX_PATH if necessary
     #
     if ("${needs_new_prefix}")
         set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${dew_cmake_prefix_path}" CACHE PATH "" FORCE)
     endif()
 
     #
-    # Add dew cmake module directory to CMAKE_MODULE_PATH if necesary
+    # Add dew cmake module directory to CMAKE_MODULE_PATH if necessary
     #
     if ("${needs_new_module_path}")
         set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${dew_cmake_module_path}" CACHE PATH "" FORCE)

--- a/dew/data/cmake/dew.cmake
+++ b/dew/data/cmake/dew.cmake
@@ -7,8 +7,11 @@
 # It is encouraged to check this file into your project's VCS. Doing so will allow your cmake project to easily
 # integrate with Dew.
 #
-cmake_minimum_required(VERSION 3.3)
-cmake_policy(SET CMP0057 NEW) # IN_LIST operator
+
+#
+# For FindPython3 (3.12) and IN_LIST operator (3.4)
+#
+cmake_minimum_required(VERSION 3.12)
 
 function(integrate_dew)
     #

--- a/dew/git.py
+++ b/dew/git.py
@@ -41,11 +41,10 @@ def checkout(repo: git.Repo, origin: git.Remote, head_name: str, ref: str) -> No
         # Calling git directly for own submodules since using relative path is not working in gitpython
         # see https://github.com/gitpython-developers/GitPython/issues/730
         if submodule.url[0:3] == '../':
-            repo.git.submodule('init', submodule.name)
-            repo.git.submodule('update', submodule.name)
+            repo.git.submodule('update', '--init', '--recursive', submodule.name)
         # For external submodules we can use the update function of gitpython
         else:
-            submodule.update(init=True)
+            submodule.update(init=True, recursive=True)
 
 
 def get_repo(url: str, destination_dir: str) -> Tuple[git.Repo, git.Remote]:


### PR DESCRIPTION
This is useful for CI builds where there's no point making a debug build every time. It's also useful to pass the compiler for environments where there are multiple compilers available.